### PR TITLE
Fix syntax error in Install.sh for non-root users

### DIFF
--- a/Install.sh
+++ b/Install.sh
@@ -14,7 +14,7 @@ then
         exit 0
     else
         echo "Papirus icon already installed!"
-        LOCAL = "/home/$USER/.icons/Papirus"
+        LOCAL="/home/$USER/.icons/Papirus"
     fi
 else
     if [ ! -d $LOCAL ]


### PR DESCRIPTION
I removed spaces around the `=` variable assignment in bash to allow installation of icons for non-root users.

Thanks for these folder icons, they're great!
![Nord Folders](https://user-images.githubusercontent.com/4692/77236082-7d030000-6b91-11ea-976e-c8332c3a86cd.png)
